### PR TITLE
Treiber für Barometer hinzugefügt

### DIFF
--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -7,7 +7,8 @@ _TOBJS +=  \
 test/test.o  \
 main/bt_driver.o  \
 main/i2c_driver.o  \
-main/mpu_driver.o
+main/mpu_driver.o  \
+main/baro_driver.o
 
 ################################################################################
 # Automatically-generated file. Do not edit!

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -4,6 +4,7 @@ main.o
 
 # Objektdateien fuer Tests
 _TOBJS +=  \
+test/test_utils.o  \
 test/test.o  \
 main/bt_driver.o  \
 main/i2c_driver.o  \
@@ -124,7 +125,7 @@ $(TOUTPUT_FILE_PATH): $(TOBJS)
 	$(QUOTE)avr-gcc$(QUOTE) -x c -DF_CPU=16000000 -DDEBUG -Os -ffunction-sections -g3 -Wall -c -std=gnu99 \
 -mmcu=atmega328p -B "$(MAKEFILE_DIR)../gcc/dev/atmega328p" \
     -D__mega328P__ \
--I"../" -I"../src/main"  \
+-I"../" -I"../src/main" -I"../src/test"  \
 -MD -MP -MF "$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$(@:%.o=%.o)"  -o "$@" "$<"
 
 	@echo Finished building: $<

--- a/src/main/baro_driver.c
+++ b/src/main/baro_driver.c
@@ -2,12 +2,47 @@
 #include "i2c_driver.h"
 #include <util/delay.h>
 
+#include "bt_driver.h"
+
 #define BMP180_ADR 0x77
 
 int16_t AC1, AC2, AC3, B1, B2, MB, MC, MD;
 uint16_t AC4, AC5, AC6;
 
-uint8_t buf[2];
+int32_t X1, X2, X3, B3, B5, B6, T, p, UT, UP;
+uint32_t B4, B7;
+
+uint8_t buf[3];
+
+uint8_t dmsg[BT_SMSG_LEN];
+
+void long_to_str(int32_t i, uint8_t *str)
+{
+    uint8_t idx, negative = 0;
+    for (idx = 0; idx < BT_SMSG_LEN; idx++)
+        str[idx] = ' ';
+    idx = BT_SMSG_LEN - 2;
+    if (i < 0)
+    {
+        i *= -1;
+        negative = 1;
+    }
+    do
+    {
+        str[idx--] = '0' + i % 10;
+        i /= 10;
+    } while (i);
+    if (negative)
+        str[idx] = '-';
+}
+
+void bt_debug(int32_t val, uint8_t dchar)
+{
+    long_to_str(val, dmsg);
+    dmsg[BT_SMSG_LEN - 1] = dchar;
+    while (!bt_send(dmsg))
+        ;
+}
 
 uint8_t baro_init(void)
 {
@@ -44,23 +79,123 @@ uint8_t baro_read_uint(uint8_t reg, uint16_t *var)
     return 1;
 }
 
-uint8_t baro_raw_temp(uint16_t *temp)
+uint8_t baro_raw_temp(int32_t *temp)
 {
     if (!i2c_write_register(BMP180_ADR, 0xF4, 0x2E))
         return 0;
     _delay_ms(5);
 
-    return baro_read_uint(0xF6, temp);
+    if (!i2c_read_register(BMP180_ADR, 0xF6, 2, buf))
+        return 0;
+
+    UT = (((int32_t)buf[1]) << 8) | buf[0];
+    *temp = UT;
+
+    return 1;
 }
 
 uint8_t baro_temp(int32_t *temp)
 {
-    uint16_t raw;
-    if (!baro_raw_temp(&raw))
+    if (!baro_raw_temp(&UT))
         return 0;
-    int32_t X1 = (((int32_t)raw - AC6) * AC5 / 32768);
-    int32_t X2 = (((int32_t)MC) * 2048 / (X1 + MD));
-    int32_t B5 = X1 + X2;
-    *temp = (B5 + 8) / 16;
+    // bt_debug(UT, '-');
+
+    X1 = (UT - AC6) * AC5 / 32768;
+    // bt_debug(X1, 'b');
+    X2 = (int32_t)MC * 2048 / (X1 + MD);
+    // bt_debug(X2, 'c');
+    B5 = X1 + X2;
+    // bt_debug(B5, 'd');
+
+    T = (B5 + 8) / 16;
+    // bt_debug(T, 't');
+    *temp = T;
+
+    return 1;
+}
+
+uint8_t baro_pres_raw(int32_t *pres, uint8_t oss)
+{
+    oss &= 0x03;
+    if (!i2c_write_register(BMP180_ADR, 0xF4, 0x34 | (oss << 6)))
+        return 0;
+    switch (oss)
+    {
+    case 0:
+        _delay_ms(5);
+        break;
+    case 1:
+        _delay_ms(8);
+        break;
+    case 2:
+        _delay_ms(14);
+        break;
+    case 3:
+        _delay_ms(26);
+    }
+
+    if (!i2c_read_register(BMP180_ADR, 0xF6, 3, buf))
+        return 0;
+    *pres = ((((int32_t)buf[2]) << 16) | ((int32_t)buf[1] << 8) | buf[0]) >> (8 - oss);
+
+    return 1;
+}
+
+uint8_t baro_pres(int32_t *pres, uint8_t oss)
+{
+    // bt_debug(AC1, 'a');
+    // bt_debug(AC2, 'b');
+    // bt_debug(AC3, 'c');
+    // bt_debug((int32_t)AC4, 'd');
+    // bt_debug((int32_t)AC5, 'e');
+    // bt_debug((int32_t)AC6, 'f');
+    // bt_debug(B1, 'g');
+    // bt_debug(B2, 'h');
+    // bt_debug(MB, 'i');
+    // bt_debug(MC, 'j');
+    // bt_debug(MD, 'k');
+
+    if (!baro_temp(&T))
+        return 0;
+    if (!baro_pres_raw(&UP, oss))
+        return 0;
+    // bt_debug(UP, 'i');
+
+    B6 = B5 - 4000;
+    // bt_debug(B6, 'z');
+    X1 = (B2 * (B6 * B6 / 4096)) / 2048;
+    // bt_debug(X1, 'y');
+    X2 = AC2 * B6 / 2048;
+    // bt_debug(X2, 'x');
+    X3 = X1 + X2;
+    // bt_debug(X3, 'w');
+    B3 = ((((int32_t)AC1 * 4 + X3) << oss) + 2) / 4;
+    // bt_debug(B3, 'v');
+    X1 = AC3 * B6 / 8192;
+    // bt_debug(X1, 'u');
+    X2 = (B1 * (B6 * B6 / 4096)) / 65536;
+    // bt_debug(X2, 't');
+    X3 = ((X1 + X2) + 2) / 4;
+    // bt_debug(X3, 's');
+    B4 = AC4 * (uint32_t)(X3 + 32768) / 32768;
+    // bt_debug(B4, 'r');
+    B7 = ((uint32_t)UP - B3) * (50000 >> oss);
+    // bt_debug(B6, 'q');
+    if (B7 < 0x80000000)
+        p = (B7 * 2) / B4;
+    else
+        p = (B7 / B4) * 2;
+    // bt_debug(p, 'p');
+    X1 = (p / 256) * (p / 256);
+    // bt_debug(X1, 'o');
+    X1 = (X1 * 3038) / 65536;
+    // bt_debug(X1, 'n');
+    X2 = (-7357 * p) / 65536;
+    // bt_debug(X2, 'm');
+    p = p + (X1 + X2 + 3791) / 16;
+    // bt_debug(p, 'l');
+
+    *pres = p;
+
     return 1;
 }

--- a/src/main/baro_driver.c
+++ b/src/main/baro_driver.c
@@ -1,51 +1,40 @@
+/**
+ * Treiber fuer Barometersensor mit I2C
+ * 
+ * Getestet mit BMP180
+ * Angeschlossen an Pin 4 und 5 am Arduino Nano (SDA, SCL)
+ **/
+
 #include "baro_driver.h"
 #include "i2c_driver.h"
 #include <util/delay.h>
 
-#include "bt_driver.h"
-
 #define BMP180_ADR 0x77
+#define BARO_READ_REGISTER(reg, len) \
+    i2c_read_register((BMP180_ADR), (reg), (len), (buf))
+#define BARO_WRITE_REGISTER(reg, data) \
+    i2c_write_register((BMP180_ADR), (reg), (data))
 
+// Konstanten aus dem EEPROM des Sensors
+// Werden zur Umrechnung der Sensorwerte verwendet
 int16_t AC1, AC2, AC3, B1, B2, MB, MC, MD;
 uint16_t AC4, AC5, AC6;
 
-int32_t X1, X2, X3, B3, B5, B6, T, p, UT, UP;
+// Zwischenwerte fuer Umrechnung der Sensorwerte
+int32_t X1, X2, X3, B3, B5, B6, UT, UP, T, p;
 uint32_t B4, B7;
 
+// Puffer fuer Auslesen von Sensorwerten
 uint8_t buf[3];
 
-uint8_t dmsg[BT_SMSG_LEN];
-
-void long_to_str(int32_t i, uint8_t *str)
-{
-    uint8_t idx, negative = 0;
-    for (idx = 0; idx < BT_SMSG_LEN; idx++)
-        str[idx] = ' ';
-    idx = BT_SMSG_LEN - 2;
-    if (i < 0)
-    {
-        i *= -1;
-        negative = 1;
-    }
-    do
-    {
-        str[idx--] = '0' + i % 10;
-        i /= 10;
-    } while (i);
-    if (negative)
-        str[idx] = '-';
-}
-
-void bt_debug(int32_t val, uint8_t dchar)
-{
-    long_to_str(val, dmsg);
-    dmsg[BT_SMSG_LEN - 1] = dchar;
-    while (!bt_send(dmsg))
-        ;
-}
-
+/**
+ * Initialisiert den Sensor, 
+ * liest Konstanten aus fuer spaetere Umrechnung der Sensorwerte aus
+ * @return Bei Erfolg 1, sonst 0
+ **/
 uint8_t baro_init(void)
 {
+    // Wenn alle Konstanten erfolgreich ausgelesen
     if (baro_read_int(0xAA, &AC1) &&
         baro_read_int(0xAC, &AC2) &&
         baro_read_int(0xAE, &AC3) &&
@@ -61,64 +50,105 @@ uint8_t baro_init(void)
     return 0;
 }
 
+/**
+ * Liest einen vorzeichenbehafteten 16-Bit Integer aus einem Register aus
+ * @param reg Registeradresse
+ * @param var Pointer fuer ausgelesenen Wert
+ * @return Bei Erfolg 1, sonst 0
+ **/
 uint8_t baro_read_int(uint8_t reg, int16_t *var)
 {
-    if (!i2c_read_register(BMP180_ADR, reg, 2, buf))
+    // Zwei Byte auslesen
+    if (!BARO_READ_REGISTER(reg, 2))
         return 0;
+    // Zusammensetzen
     *var = (((int16_t)buf[1]) << 8) | buf[0];
 
     return 1;
 }
 
+/**
+ * Liest einen vorzeichenunbehafteten 16-Bit Integer aus einem Register aus
+ * @param reg Registeradresse
+ * @param var Pointer fuer ausgelesenen Wert
+ **/
 uint8_t baro_read_uint(uint8_t reg, uint16_t *var)
 {
-    if (!i2c_read_register(BMP180_ADR, reg, 2, buf))
+    // Zwei Byte auslesen
+    if (!BARO_READ_REGISTER(reg, 2))
         return 0;
+    // Zusammensetzen
     *var = (((uint16_t)buf[1]) << 8) | buf[0];
 
     return 1;
 }
 
-uint8_t baro_raw_temp(int32_t *temp)
+/**
+ * Liest den Rohwert des Temperatursensors aus
+ * @param temp Pointer fuer ausgelesenen Wert
+ * @return Bei Erfolg 1, sonst 0
+ **/
+uint8_t baro_temp_raw(int32_t *temp)
 {
-    if (!i2c_write_register(BMP180_ADR, 0xF4, 0x2E))
+    // Temperaturmessung anfordern
+    if (!BARO_WRITE_REGISTER(0xF4, 0x2E))
         return 0;
+
+    // Warten auf Abschluss der Messung
     _delay_ms(5);
 
-    if (!i2c_read_register(BMP180_ADR, 0xF6, 2, buf))
+    // Zwei Byte auslesen
+    if (!BARO_READ_REGISTER(0xF6, 2))
         return 0;
 
+    // Zusammensetzen
     UT = (((int32_t)buf[1]) << 8) | buf[0];
     *temp = UT;
 
     return 1;
 }
 
+/**
+ * Liest die Temperatur aus und rechnet sie in 0.1 Grad Celsius (C*10^-1) um
+ * @param temp Pointer fuer ausgelesene Temperatur
+ * @return Bei Erfolg 1, sonst 0
+ **/
 uint8_t baro_temp(int32_t *temp)
 {
-    if (!baro_raw_temp(&UT))
+    // Rohwert auslesen
+    if (!baro_temp_raw(&UT))
         return 0;
-    // bt_debug(UT, '-');
 
+    // Berechnung Temperatur in 0.1 Grad Celsius
+    // Formel siehe Datenblatt
     X1 = (UT - AC6) * AC5 / 32768;
-    // bt_debug(X1, 'b');
     X2 = (int32_t)MC * 2048 / (X1 + MD);
-    // bt_debug(X2, 'c');
     B5 = X1 + X2;
-    // bt_debug(B5, 'd');
 
     T = (B5 + 8) / 16;
-    // bt_debug(T, 't');
     *temp = T;
 
     return 1;
 }
 
+/**
+ * Liest den Rohwert des Luftdrucksensors aus, 
+ * Genaugkeit durch Oversamplingrate bestimmbar
+ * @param pres Pointer fuer ausgelesenen Wert
+ * @param oss Oversamplingwert (0 bis 3)
+ * @return Bei Erfolg 1, sonst 0
+ **/
 uint8_t baro_pres_raw(int32_t *pres, uint8_t oss)
 {
+    // Oversamplingwert begrenzen
     oss &= 0x03;
-    if (!i2c_write_register(BMP180_ADR, 0xF4, 0x34 | (oss << 6)))
+
+    // Luftdruckmessung anfordern
+    if (!BARO_WRITE_REGISTER(0xF4, 0x34 | (oss << 6)))
         return 0;
+
+    // Warten auf Abschluss der Messung
+    // Dauer von Oversamplingrate abhaengig
     switch (oss)
     {
     case 0:
@@ -130,71 +160,57 @@ uint8_t baro_pres_raw(int32_t *pres, uint8_t oss)
     case 2:
         _delay_ms(14);
         break;
-    case 3:
+    default:
         _delay_ms(26);
     }
 
-    if (!i2c_read_register(BMP180_ADR, 0xF6, 3, buf))
+    // Zwei Byte auslesen
+    if (!BARO_READ_REGISTER(0xF6, 3))
         return 0;
-    *pres = ((((int32_t)buf[2]) << 16) | ((int32_t)buf[1] << 8) | buf[0]) >> (8 - oss);
+
+    // Zusammensetzen
+    UP = ((((int32_t)buf[2]) << 16) | ((int32_t)buf[1] << 8) | buf[0]) >> (8 - oss);
+    *pres = UP;
 
     return 1;
 }
 
+/**
+ * Liest den Luftdruck aus und rechnet ihn in Pascal um
+ * @param pres Pointer fuer ausgelesenen Wert
+ * @param oss Oversamplingwert (0 bis 3)
+ * @return Bei Erfolg 1, sonst 0
+ **/
 uint8_t baro_pres(int32_t *pres, uint8_t oss)
 {
-    // bt_debug(AC1, 'a');
-    // bt_debug(AC2, 'b');
-    // bt_debug(AC3, 'c');
-    // bt_debug((int32_t)AC4, 'd');
-    // bt_debug((int32_t)AC5, 'e');
-    // bt_debug((int32_t)AC6, 'f');
-    // bt_debug(B1, 'g');
-    // bt_debug(B2, 'h');
-    // bt_debug(MB, 'i');
-    // bt_debug(MC, 'j');
-    // bt_debug(MD, 'k');
-
+    // Temperatur wird fuer Luftdruckumrechnung benoetigt
     if (!baro_temp(&T))
         return 0;
+    // Rohwert des Luftdrucks auslesen
     if (!baro_pres_raw(&UP, oss))
         return 0;
-    // bt_debug(UP, 'i');
 
+    // Berechnung Luftdruck in Pascal
+    // Formel siehe Datenblatt
     B6 = B5 - 4000;
-    // bt_debug(B6, 'z');
     X1 = (B2 * (B6 * B6 / 4096)) / 2048;
-    // bt_debug(X1, 'y');
     X2 = AC2 * B6 / 2048;
-    // bt_debug(X2, 'x');
     X3 = X1 + X2;
-    // bt_debug(X3, 'w');
     B3 = ((((int32_t)AC1 * 4 + X3) << oss) + 2) / 4;
-    // bt_debug(B3, 'v');
     X1 = AC3 * B6 / 8192;
-    // bt_debug(X1, 'u');
     X2 = (B1 * (B6 * B6 / 4096)) / 65536;
-    // bt_debug(X2, 't');
     X3 = ((X1 + X2) + 2) / 4;
-    // bt_debug(X3, 's');
     B4 = AC4 * (uint32_t)(X3 + 32768) / 32768;
-    // bt_debug(B4, 'r');
     B7 = ((uint32_t)UP - B3) * (50000 >> oss);
-    // bt_debug(B6, 'q');
     if (B7 < 0x80000000)
         p = (B7 * 2) / B4;
     else
         p = (B7 / B4) * 2;
-    // bt_debug(p, 'p');
     X1 = (p / 256) * (p / 256);
-    // bt_debug(X1, 'o');
     X1 = (X1 * 3038) / 65536;
-    // bt_debug(X1, 'n');
     X2 = (-7357 * p) / 65536;
-    // bt_debug(X2, 'm');
-    p = p + (X1 + X2 + 3791) / 16;
-    // bt_debug(p, 'l');
 
+    p = p + (X1 + X2 + 3791) / 16;
     *pres = p;
 
     return 1;

--- a/src/main/baro_driver.c
+++ b/src/main/baro_driver.c
@@ -1,0 +1,66 @@
+#include "baro_driver.h"
+#include "i2c_driver.h"
+#include <util/delay.h>
+
+#define BMP180_ADR 0x77
+
+int16_t AC1, AC2, AC3, B1, B2, MB, MC, MD;
+uint16_t AC4, AC5, AC6;
+
+uint8_t buf[2];
+
+uint8_t baro_init(void)
+{
+    if (baro_read_int(0xAA, &AC1) &&
+        baro_read_int(0xAC, &AC2) &&
+        baro_read_int(0xAE, &AC3) &&
+        baro_read_uint(0xB0, &AC4) &&
+        baro_read_uint(0xB2, &AC5) &&
+        baro_read_uint(0xB4, &AC6) &&
+        baro_read_int(0xB6, &B1) &&
+        baro_read_int(0xB8, &B2) &&
+        baro_read_int(0xBA, &MB) &&
+        baro_read_int(0xBC, &MC) &&
+        baro_read_int(0xBE, &MD))
+        return 1;
+    return 0;
+}
+
+uint8_t baro_read_int(uint8_t reg, int16_t *var)
+{
+    if (!i2c_read_register(BMP180_ADR, reg, 2, buf))
+        return 0;
+    *var = (((int16_t)buf[1]) << 8) | buf[0];
+
+    return 1;
+}
+
+uint8_t baro_read_uint(uint8_t reg, uint16_t *var)
+{
+    if (!i2c_read_register(BMP180_ADR, reg, 2, buf))
+        return 0;
+    *var = (((uint16_t)buf[1]) << 8) | buf[0];
+
+    return 1;
+}
+
+uint8_t baro_raw_temp(uint16_t *temp)
+{
+    if (!i2c_write_register(BMP180_ADR, 0xF4, 0x2E))
+        return 0;
+    _delay_ms(5);
+
+    return baro_read_uint(0xF6, temp);
+}
+
+uint8_t baro_temp(int32_t *temp)
+{
+    uint16_t raw;
+    if (!baro_raw_temp(&raw))
+        return 0;
+    int32_t X1 = (((int32_t)raw - AC6) * AC5 / 32768);
+    int32_t X2 = (((int32_t)MC) * 2048 / (X1 + MD));
+    int32_t B5 = X1 + X2;
+    *temp = (B5 + 8) / 16;
+    return 1;
+}

--- a/src/main/baro_driver.h
+++ b/src/main/baro_driver.h
@@ -6,7 +6,7 @@
 uint8_t baro_init(void);
 uint8_t baro_read_int(uint8_t reg, int16_t *var);
 uint8_t baro_read_uint(uint8_t reg, uint16_t *var);
-uint8_t baro_raw_temp(int32_t *temp);
+uint8_t baro_temp_raw(int32_t *temp);
 uint8_t baro_temp(int32_t *temp);
 uint8_t baro_pres_raw(int32_t *pres, uint8_t oss);
 uint8_t baro_pres(int32_t *pres, uint8_t oss);

--- a/src/main/baro_driver.h
+++ b/src/main/baro_driver.h
@@ -1,0 +1,12 @@
+#ifndef BARO_DRIVER_H_
+#define BARO_DRIVER_H_
+
+#include <avr/io.h>
+
+uint8_t baro_init(void);
+uint8_t baro_read_int(uint8_t reg, int16_t *var);
+uint8_t baro_read_uint(uint8_t reg, uint16_t *var);
+uint8_t baro_raw_temp(uint16_t *temp);
+uint8_t baro_temp(int32_t *temp);
+
+#endif /* BARO_DRIVER_H_ */

--- a/src/main/baro_driver.h
+++ b/src/main/baro_driver.h
@@ -6,7 +6,9 @@
 uint8_t baro_init(void);
 uint8_t baro_read_int(uint8_t reg, int16_t *var);
 uint8_t baro_read_uint(uint8_t reg, uint16_t *var);
-uint8_t baro_raw_temp(uint16_t *temp);
+uint8_t baro_raw_temp(int32_t *temp);
 uint8_t baro_temp(int32_t *temp);
+uint8_t baro_pres_raw(int32_t *pres, uint8_t oss);
+uint8_t baro_pres(int32_t *pres, uint8_t oss);
 
 #endif /* BARO_DRIVER_H_ */

--- a/src/main/bt_driver.h
+++ b/src/main/bt_driver.h
@@ -8,7 +8,7 @@
 #define BAUD 9600
 #define MYUBRR (FOSC / 16 / BAUD - 1)
 
-#define BT_SMSG_LEN 7
+#define BT_SMSG_LEN 12
 #define BT_RMSG_LEN 2
 #define BT_TIMEOUT 6
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -1,10 +1,8 @@
 #include "bt_driver.h"
 #include "mpu_driver.h"
 #include "baro_driver.h"
+#include "test_utils.h"
 #include <util/delay.h>
-
-void int_to_str(int16_t i, uint8_t *str);
-void long_to_str(int32_t i, uint8_t *str);
 
 uint8_t msg[BT_RMSG_LEN > BT_SMSG_LEN ? BT_RMSG_LEN : BT_SMSG_LEN];
 int16_t ax, ay, az;
@@ -24,13 +22,13 @@ int main(void)
 
     while (1)
     {
-        // if (!baro_temp(&temp))
-        //     PORTB |= _BV(PB5);
+        if (!baro_temp(&temp))
+            PORTB |= _BV(PB5);
 
-        // long_to_str(temp, msg);
-        // msg[BT_SMSG_LEN - 1] = ' ';
-        // while (!(bt_send(msg)))
-        //     ;
+        long_to_str(temp, msg);
+        msg[BT_SMSG_LEN - 1] = ' ';
+        while (!(bt_send(msg)))
+            ;
 
         if (!baro_pres(&pres, 1))
             PORTB |= _BV(PB5);
@@ -40,50 +38,19 @@ int main(void)
         while (!bt_send(msg))
             ;
 
+        // mpu_get_accel(&ax, &ay, &az);
+
+        // int_to_str(ax, msg);
+        // while (!(bt_send(msg)))
+        //     ;
+        // int_to_str(ay, msg);
+        // while (!(bt_send(msg)))
+        //     ;
+        // int_to_str(az, msg);
+        // msg[5] = '\n';
+        // while (!(bt_send(msg)))
+        //     ;
+
         _delay_ms(500);
-
-        /*mpu_get_accel(&ax, &ay, &az);
-
-        int_to_str(ax, msg);
-        while (!(bt_send(msg)))
-            ;
-        int_to_str(ay, msg);
-        while (!(bt_send(msg)))
-            ;
-        int_to_str(az, msg);
-        msg[5] = '\n';
-        while (!(bt_send(msg)))
-            ;
-        _delay_ms(50);*/
     }
 }
-
-/**
- * Konvertiert einen vorzeichenbehafteten Integer in einen String
- * @param i Zu konvertierender Integer
- * @param str Ausgabearray der Laenge 7
- **/
-void int_to_str(int16_t i, uint8_t *str)
-{
-    long_to_str((int16_t)i, str);
-}
-
-// void long_to_str(int32_t i, uint8_t *str)
-// {
-//     uint8_t idx, negative = 0;
-//     for (idx = 0; idx < BT_SMSG_LEN; idx++)
-//         str[idx] = ' ';
-//     idx = BT_SMSG_LEN - 2;
-//     if (i < 0)
-//     {
-//         i *= -1;
-//         negative = 1;
-//     }
-//     do
-//     {
-//         str[idx--] = '0' + i % 10;
-//         i /= 10;
-//     } while (i);
-//     if (negative)
-//         str[idx] = '-';
-// }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -4,10 +4,11 @@
 #include <util/delay.h>
 
 void int_to_str(int16_t i, uint8_t *str);
+void long_to_str(int32_t i, uint8_t *str);
 
 uint8_t msg[BT_RMSG_LEN > BT_SMSG_LEN ? BT_RMSG_LEN : BT_SMSG_LEN];
 int16_t ax, ay, az;
-int32_t temp;
+int32_t temp, pres;
 
 int main(void)
 {
@@ -23,14 +24,23 @@ int main(void)
 
     while (1)
     {
-        if (!baro_temp(&temp))
+        // if (!baro_temp(&temp))
+        //     PORTB |= _BV(PB5);
+
+        // long_to_str(temp, msg);
+        // msg[BT_SMSG_LEN - 1] = ' ';
+        // while (!(bt_send(msg)))
+        //     ;
+
+        if (!baro_pres(&pres, 1))
             PORTB |= _BV(PB5);
 
-        int_to_str((int16_t)temp, msg);
-        msg[6] = '\n';
-        while (!(bt_send(msg)))
+        long_to_str(pres, msg);
+        msg[BT_SMSG_LEN - 1] = '\n';
+        while (!bt_send(msg))
             ;
-        _delay_ms(2000);
+
+        _delay_ms(500);
 
         /*mpu_get_accel(&ax, &ay, &az);
 
@@ -55,20 +65,25 @@ int main(void)
  **/
 void int_to_str(int16_t i, uint8_t *str)
 {
-    uint8_t idx, negative = 0;
-    for (idx = 0; idx < 7; idx++)
-        str[idx] = ' ';
-    idx = 5;
-    if (i < 0)
-    {
-        i *= -1;
-        negative = 1;
-    }
-    do
-    {
-        str[idx--] = '0' + i % 10;
-        i /= 10;
-    } while (i);
-    if (negative)
-        str[idx] = '-';
+    long_to_str((int16_t)i, str);
 }
+
+// void long_to_str(int32_t i, uint8_t *str)
+// {
+//     uint8_t idx, negative = 0;
+//     for (idx = 0; idx < BT_SMSG_LEN; idx++)
+//         str[idx] = ' ';
+//     idx = BT_SMSG_LEN - 2;
+//     if (i < 0)
+//     {
+//         i *= -1;
+//         negative = 1;
+//     }
+//     do
+//     {
+//         str[idx--] = '0' + i % 10;
+//         i /= 10;
+//     } while (i);
+//     if (negative)
+//         str[idx] = '-';
+// }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -1,23 +1,38 @@
 #include "bt_driver.h"
 #include "mpu_driver.h"
+#include "baro_driver.h"
 #include <util/delay.h>
 
 void int_to_str(int16_t i, uint8_t *str);
 
 uint8_t msg[BT_RMSG_LEN > BT_SMSG_LEN ? BT_RMSG_LEN : BT_SMSG_LEN];
 int16_t ax, ay, az;
+int32_t temp;
 
 int main(void)
 {
     /* Testprogramm */
     bt_init();
-    mpu_init();
+    // mpu_init();
+    baro_init();
+
+    DDRB |= _BV(PB5);
+    PORTB &= ~_BV(PB5);
 
     sei();
 
     while (1)
     {
-        mpu_get_accel(&ax, &ay, &az);
+        if (!baro_temp(&temp))
+            PORTB |= _BV(PB5);
+
+        int_to_str((int16_t)temp, msg);
+        msg[6] = '\n';
+        while (!(bt_send(msg)))
+            ;
+        _delay_ms(2000);
+
+        /*mpu_get_accel(&ax, &ay, &az);
 
         int_to_str(ax, msg);
         while (!(bt_send(msg)))
@@ -29,7 +44,7 @@ int main(void)
         msg[5] = '\n';
         while (!(bt_send(msg)))
             ;
-        _delay_ms(50);
+        _delay_ms(50);*/
     }
 }
 

--- a/src/test/test_utils.c
+++ b/src/test/test_utils.c
@@ -1,0 +1,57 @@
+#include "test_utils.h"
+#include "bt_driver.h"
+
+uint8_t dmsg[BT_SMSG_LEN];
+
+/**
+ * Konvertiert einen vorzeichenbehafteten 32-Bit-Integer in einen String
+ * @param i Zu konvertierender 32-Bit-Integer
+ * @param str Ausgabearray der Laenge 7
+ **/
+void long_to_str(int32_t i, uint8_t *str)
+{
+    uint8_t idx, negative = 0;
+    // String leeren
+    for (idx = 0; idx < BT_SMSG_LEN; idx++)
+        str[idx] = ' ';
+    idx = BT_SMSG_LEN - 2;
+    // Betrag und Vorzeichen der Eingabe bestimmen
+    if (i < 0)
+    {
+        i *= -1;
+        negative = 1;
+    }
+    // Ziffern in Buchstaben umwandeln
+    do
+    {
+        str[idx--] = '0' + i % 10;
+        i /= 10;
+    } while (i);
+    // Vorzeichen hinzufügen falls Zahl negativ
+    if (negative)
+        str[idx] = '-';
+}
+
+/**
+ * Konvertiert einen vorzeichenbehafteten 16-Bit-Integer in einen String
+ * @param i Zu konvertierender 16-Bit-Integer
+ * @param str Ausgabearray der Laenge 7
+ **/
+void int_to_str(int16_t i, uint8_t *str)
+{
+    long_to_str((int16_t)i, str);
+}
+
+/**
+ * Sendet einen vorzeichenbehafteten 32-Bit-Integer lesbar in ASCII per Bluetooth. 
+ * Die Debugnachricht wird mit einem gegeben Buchstaben zur Wiedererkennung markiert
+ * @param val Zu sendender 32-Bit-Integer
+ * @param dchar Markierungsbuchstabe
+ **/
+void bt_debug(int32_t val, uint8_t dchar)
+{
+    long_to_str(val, dmsg);
+    dmsg[BT_SMSG_LEN - 1] = dchar;
+    while (!bt_send(dmsg))
+        ;
+}

--- a/src/test/test_utils.h
+++ b/src/test/test_utils.h
@@ -1,0 +1,15 @@
+#ifndef TEST_UTILS_H_
+#define TEST_UTILS_H_
+
+#include <avr/io.h>
+
+void long_to_str(int32_t i, uint8_t *str);
+void int_to_str(int16_t i, uint8_t *str);
+
+#ifdef DEBUG
+#define BT_DEBUG(val, dchar) bt_debug(val, dchar)
+#else
+#define BT_DEBUG(val, dchar)
+#endif
+
+#endif /* UTILS_H_ */


### PR DESCRIPTION
Der Treiber ermöglicht das Auslesen von Temperatur und Druck, Rohwerte oder in physikalische Einheiten umgerechnet.
Einige für Tests hilfreiche Funktionen wurden ausgelagert, um den Code etwas aufzuräumen.