### PR TITLE
Servo-Treiber hinzugefügt

### DIFF
--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -9,7 +9,8 @@ test/test.o  \
 main/bt_driver.o  \
 main/i2c_driver.o  \
 main/mpu_driver.o  \
-main/baro_driver.o
+main/baro_driver.o  \
+main/servo_driver.o
 
 ################################################################################
 # Automatically-generated file. Do not edit!

--- a/src/main/bt_driver.c
+++ b/src/main/bt_driver.c
@@ -115,7 +115,7 @@ ISR(USART_RX_vect)
 }
 
 // Timer-Overflow Interrupt
-ISR(TIMER2_OVF_vect)
+ISR(TIMER0_OVF_vect)
 {
     // Wenn timeout erreicht (pro Interrupt ca. 16ms)
     if (timeout++ > (BT_TIMEOUT - 2))
@@ -125,5 +125,6 @@ ISR(TIMER2_OVF_vect)
             ridx = 0;
         // Timer stoppen
         TCCR0B = 0;
+        timeout = 0;
     }
 }

--- a/src/main/bt_driver.h
+++ b/src/main/bt_driver.h
@@ -9,7 +9,7 @@
 #define MYUBRR (FOSC / 16 / BAUD - 1)
 
 #define BT_SMSG_LEN 12
-#define BT_RMSG_LEN 2
+#define BT_RMSG_LEN 1
 #define BT_TIMEOUT 6
 
 void bt_init(void);

--- a/src/main/servo_driver.c
+++ b/src/main/servo_driver.c
@@ -1,0 +1,47 @@
+/**
+ * Treiber fuer Servo mit PWM
+ * 
+ * Getestet mit Micro Servo SG90
+ * Angeschlossen an Pin 10 am Arduino Nano (OC1B)
+ **/
+#include "servo_driver.h"
+#include <avr/interrupt.h>
+
+uint16_t val;
+
+/**
+ * Initialisiert den Servo
+ * Verwendet Fast PWM mit Timer 1
+ **/
+void servo_init(void)
+{
+    // Pin 10 als Output setzen
+    DDRB |= _BV(PB2);
+    // Periodendauer 20ms
+    OCR1A = 40000;
+    // Pin 10 LOW bei Compare Match
+    // Modus Fast PWM mit OCR1A als TOP
+    TCCR1A = _BV(COM1B1) | _BV(WGM11) | _BV(WGM10);
+    TCCR1B = _BV(WGM13) | _BV(WGM12);
+}
+
+/**
+ * Stellt den Winkel fuer den Servomotor ein
+ * @param deg Winkel von 0 bis 180 Grad
+ **/
+void servo_set_deg(uint8_t deg)
+{
+    // Winkel auf [0, 180] limitieren
+    if (deg > 180)
+        deg = 180;
+    // Wert fuer OCR1B berechnen
+    val = (uint16_t)((uint32_t)deg * 1994 / 100 + 1108);
+    // Timer ausschalten
+    TCCR1B &= ~_BV(CS11);
+    // Wert von val in Register schreiben
+    OCR1BH = (uint8_t)(val >> 8);
+    OCR1BL = (uint8_t)(val);
+    // Timer aktivieren
+    TCNT1 = 0;
+    TCCR1B |= _BV(CS11);
+}

--- a/src/main/servo_driver.h
+++ b/src/main/servo_driver.h
@@ -1,0 +1,9 @@
+#ifndef SERVO_DRIVER_H_
+#define SERVO_DRIVER_H_
+
+#include <avr/io.h>
+
+void servo_init(void);
+void servo_set_deg(uint8_t deg);
+
+#endif /* SERVO_DRIVER_H_ */

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -2,9 +2,11 @@
 #include "mpu_driver.h"
 #include "baro_driver.h"
 #include "test_utils.h"
+#include "servo_driver.h"
 #include <util/delay.h>
 
-uint8_t msg[BT_RMSG_LEN > BT_SMSG_LEN ? BT_RMSG_LEN : BT_SMSG_LEN];
+uint8_t smsg[BT_SMSG_LEN];
+uint8_t rmsg[BT_RMSG_LEN];
 int16_t ax, ay, az;
 int32_t temp, pres;
 
@@ -14,6 +16,9 @@ int main(void)
     bt_init();
     // mpu_init();
     baro_init();
+    servo_init();
+
+    servo_set_deg(0);
 
     DDRB |= _BV(PB5);
     PORTB &= ~_BV(PB5);
@@ -22,20 +27,23 @@ int main(void)
 
     while (1)
     {
+        if (bt_get(rmsg))
+            servo_set_deg(rmsg[0]);
+
         if (!baro_temp(&temp))
             PORTB |= _BV(PB5);
 
-        long_to_str(temp, msg);
-        msg[BT_SMSG_LEN - 1] = ' ';
-        while (!(bt_send(msg)))
+        long_to_str(temp, smsg);
+        smsg[BT_SMSG_LEN - 1] = ' ';
+        while (!(bt_send(smsg)))
             ;
 
         if (!baro_pres(&pres, 1))
             PORTB |= _BV(PB5);
 
-        long_to_str(pres, msg);
-        msg[BT_SMSG_LEN - 1] = '\n';
-        while (!bt_send(msg))
+        long_to_str(pres, smsg);
+        smsg[BT_SMSG_LEN - 1] = '\n';
+        while (!bt_send(smsg))
             ;
 
         // mpu_get_accel(&ax, &ay, &az);


### PR DESCRIPTION
Treiber verwendet Fast PWM mit Timer 1
Es kann ein Winkel zwischen 0 und 180 eingestellt werden
Fehler an Bluetooth-Treiber behoben (falscher Interrupt-Vektor)